### PR TITLE
Concurrently upgrade to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "api-server": "better-npm-run api-server",
     "auth-server": "better-npm-run auth-server",
     "build": "better-npm-run build",
-    "dev": "concurrent --kill-others \"npm run watch-client\" \"npm run api-server\" \"npm run auth-server\" \"npm run dev-server\"",
+    "dev": "concurrently --kill-others \"npm run watch-client\" \"npm run api-server\" \"npm run auth-server\" \"npm run dev-server\"",
     "dev-server": "better-npm-run dev-server",
     "lint": "eslint -c .eslintrc src",
     "postinstall": "./bin/build_for_heroku.sh",
-    "start": "concurrent --kill-others \"better-npm-run api\" \"better-npm-run auth\" \"better-npm-run server\"",
+    "start": "concurrently --kill-others \"better-npm-run api\" \"better-npm-run auth\" \"better-npm-run server\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch-client": "better-npm-run watch-client"
   },
@@ -88,7 +88,7 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.14.2",
-    "concurrently": "1.0.0",
+    "concurrently": "2.0.0",
     "jsonwebtoken": "^5.4.1",
     "superagent": "^1.6.1",
     "universal-redux": "3.0.0-rc29"


### PR DESCRIPTION
I was running into some trouble with npm 3.5.1 using concurrently (from /node_modules/.bin) it is referencing require('./lodash-mixins'), not present in the local .bin directory. An upgrade to concurrently 2.0.0 solves this, it also exposes the 'concurrently' binary, instead of 'concurrent', which should reduce the name clash with the concurrent npm package.
